### PR TITLE
Fix error when no arguments supplied

### DIFF
--- a/src/main/java/net/craftminecraft/bungee/movemenow/ReloadCommand.java
+++ b/src/main/java/net/craftminecraft/bungee/movemenow/ReloadCommand.java
@@ -17,10 +17,11 @@ public class ReloadCommand extends Command {
     public void execute(CommandSender sender, String[] args) {
         if (args.length != 1) {
             sender.sendMessage(new TextComponent("Please use /mmn reload."));
-        }
-        switch (args[0]) {
-            case "reload":
-                plugin.loadConfig();
+        } else {
+            switch (args[0]) {
+                case "reload":
+                    plugin.loadConfig();
+            }
         }
     }
 }


### PR DESCRIPTION
An ArrayIndexOutOfBoundsException would be thrown if no arguments were supplied. Putting the switch-statement into the else-branch should fix this.