### PR TITLE
Update Maven dependencies to work on newer Bungee versions

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,9 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+/misc.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings" defaultProject="true" />
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,15 +8,17 @@
     <version>1.2</version>
     <repositories>
         <repository>
-            <id>dev-cmc</id>
-            <url>http://nexus.cmc.im/content/groups/public/</url>
+            <id>bungeecord-repo</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
     </repositories>
     <dependencies>
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.7-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>
@@ -33,8 +35,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/net/craftminecraft/bungee/movemenow/ReloadCommand.java
+++ b/src/main/java/net/craftminecraft/bungee/movemenow/ReloadCommand.java
@@ -1,11 +1,12 @@
 package net.craftminecraft.bungee.movemenow;
 
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.TabExecutor;
+import java.util.ArrayList;
 
-public class ReloadCommand extends Command {
+public class ReloadCommand extends Command implements TabExecutor {
     MoveMeNow plugin;
 
     public ReloadCommand(MoveMeNow plugin) {
@@ -22,5 +23,13 @@ public class ReloadCommand extends Command {
             case "reload":
                 plugin.loadConfig();
         }
+    }
+
+    @Override
+    public Iterable<String> onTabComplete(CommandSender sender, String[] args)
+    {
+        ArrayList<String> list = new ArrayList<>();
+        list.add("reload");
+        return list;
     }
 }

--- a/src/main/java/net/craftminecraft/bungee/movemenow/ReloadCommand.java
+++ b/src/main/java/net/craftminecraft/bungee/movemenow/ReloadCommand.java
@@ -18,10 +18,13 @@ public class ReloadCommand extends Command implements TabExecutor {
     public void execute(CommandSender sender, String[] args) {
         if (args.length != 1) {
             sender.sendMessage(new TextComponent("Please use /mmn reload."));
+            return;
         }
         switch (args[0]) {
             case "reload":
                 plugin.loadConfig();
+                sender.sendMessage(new TextComponent("Reloaded config!"));
+                break;
         }
     }
 

--- a/src/main/java/net/craftminecraft/bungee/movemenow/ReloadCommand.java
+++ b/src/main/java/net/craftminecraft/bungee/movemenow/ReloadCommand.java
@@ -20,11 +20,9 @@ public class ReloadCommand extends Command implements TabExecutor {
             sender.sendMessage(new TextComponent("Please use /mmn reload."));
             return;
         }
-        switch (args[0]) {
-            case "reload":
-                plugin.loadConfig();
-                sender.sendMessage(new TextComponent("Reloaded config!"));
-                break;
+        if (args[0].equals("reload")) {
+            plugin.loadConfig();
+            sender.sendMessage(new TextComponent("Reloaded config!"));
         }
     }
 


### PR DESCRIPTION
As the title says. The plugin itself sadly doesnt work on newer versions of Bungee, so I basically only updated the Maven Dependencies in the `pom.xml`-File, for it to work again. Tested on BungeeCord for the 1.21.1, works flawlessly there.